### PR TITLE
stewardess is now browserifyable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var events       = require('events')
   ;
 
 try {
-  mongoose = require('mongoose');
+  mongoose = require('' + 'mongoose'); // hack to make work with browserify
 } catch (e) { }
 
 // create a new instance of Stewardess and return it
@@ -70,7 +70,7 @@ Stewardess.prototype.run = function() {
     if (err === 'skip') queuePos += 1;
     if (err === 'repeat') queuePos -= 1;
     if (err === 'previous') queuePos = Math.max(queuePos - 2, 0);
-    setImmediate(next);
+    nextTick(next);
   });
 
   // start
@@ -170,4 +170,14 @@ Stewardess.prototype.contextOn = function(event, fn) {
     fn.apply(self.context, arguments);
   });
   return self;
+}
+
+function nextTick(cb) {
+  if (typeof setImmediate !== 'undefined') {
+    setImmediate(cb);
+  } else if (typeof process !== 'undefined' && process && process.nextTick) {
+    process.nextTick(cb);
+  } else {
+    setTimeout(cb, 0);
+  }
 }


### PR DESCRIPTION
make `require('mongoose')` and expression so browserify will skip it.

Allow for setImmediate, process.nextTick, or fall back to setTimeout.

![7htcfhq](https://f.cloud.github.com/assets/678338/1010457/2aca2bc2-0b4b-11e3-913a-9faf1c58eb80.gif)
