### PR TITLE
require colors if used

### DIFF
--- a/plugins/timer.js
+++ b/plugins/timer.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var colors = require('colors')
-  , defaults = require('./defaults')
-  ;
+var defaults = require('./defaults');
 
 function timer(stewardess, options) {
+  var colors = require('colors');
+
   options = defaults(options, {
     slow: 0,
     log: console.log.bind(console),


### PR DESCRIPTION
A strange bug exists when you require stewardess in IE 8/9. 

String.prototype doesn't support **defineGetter**

This was suspected to be because of the colors module. Changed the requires.
![a](http://i.imgur.com/3m1yHzp.gif)
